### PR TITLE
fix: fix to enable asynchronous output of results

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,13 +53,15 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		results, err := e.Run(cmd.Context())
-		if err != nil {
-			return err
-		}
+
+		resultCh := make(chan *exector.Result)
+		errCh := make(chan error)
+
+		go e.Run(cmd.Context(), resultCh, errCh)
 		exitCode := 0
 		killed := false
-		for _, r := range results {
+	L:
+		for r := range resultCh {
 			fmt.Println("--------------------------------------------------")
 			_, _ = fmt.Fprintf(os.Stdout, "%s %s\n", commandPointer, r.Command)
 			_, _ = os.Stdout.Write(r.Combined)
@@ -72,6 +74,20 @@ var rootCmd = &cobra.Command{
 			}
 			d := r.EndTime.Sub(r.StartTime)
 			fmt.Printf("---- [ exit code: %d, excution time: %s ]\n", r.ExitCode, d)
+			select {
+			case errr := <-errCh:
+				err = errr
+				break L
+			default:
+			}
+		}
+		select {
+		case errr := <-errCh:
+			err = errr
+		default:
+		}
+		if err != nil {
+			return err
 		}
 		if exitCode != 0 {
 			os.Exit(exitCode)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,11 +81,10 @@ var rootCmd = &cobra.Command{
 			default:
 			}
 		}
-		select {
-		case errr := <-errCh:
-			err = errr
-		default:
+		if err != nil {
+			return err
 		}
+		err = <-errCh
 		if err != nil {
 			return err
 		}

--- a/exector/exector.go
+++ b/exector/exector.go
@@ -48,15 +48,18 @@ func New(commands []string, opts ...Option) (*Executor, error) {
 	return e, nil
 }
 
-func (e *Executor) Run(ctx context.Context) ([]*Result, error) {
+func (e *Executor) Run(ctx context.Context, ch chan<- *Result, errCh chan<- error) {
+	defer close(ch)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	sh, err := exec.LookPath(e.shell)
 	if err != nil {
-		return nil, err
+		if errCh != nil {
+			errCh <- err
+		}
+		return
 	}
 	var eg errgroup.Group
-	var results []*Result
 	eg.SetLimit(runtime.GOMAXPROCS(0) - 1)
 	for _, c := range e.commands {
 		eg.Go(func() error {
@@ -78,7 +81,9 @@ func (e *Executor) Run(ctx context.Context) ([]*Result, error) {
 					StartTime: start,
 					EndTime:   time.Now(),
 				}
-				results = append(results, result)
+				if ch != nil {
+					ch <- result
+				}
 			}()
 			start = time.Now()
 			if err := cmd.Run(); err != nil {
@@ -97,7 +102,10 @@ func (e *Executor) Run(ctx context.Context) ([]*Result, error) {
 		})
 	}
 	if err := eg.Wait(); err != nil {
-		return nil, err
+		if errCh != nil {
+			errCh <- err
+		}
+		return
 	}
-	return results, nil
+	return
 }

--- a/exector/exector.go
+++ b/exector/exector.go
@@ -50,6 +50,7 @@ func New(commands []string, opts ...Option) (*Executor, error) {
 
 func (e *Executor) Run(ctx context.Context, ch chan<- *Result, errCh chan<- error) {
 	defer close(ch)
+	defer close(errCh)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	sh, err := exec.LookPath(e.shell)
@@ -105,7 +106,5 @@ func (e *Executor) Run(ctx context.Context, ch chan<- *Result, errCh chan<- erro
 		if errCh != nil {
 			errCh <- err
 		}
-		return
 	}
-	return
 }

--- a/exector/executor_test.go
+++ b/exector/executor_test.go
@@ -147,20 +147,17 @@ func TestRun(t *testing.T) {
 			var results []*Result
 		L:
 			for r := range resultCh {
+				results = append(results, r)
 				select {
 				case errr := <-errCh:
 					err = errr
 					break L
 				default:
 				}
-				results = append(results, r)
 			}
-			select {
-			case errr := <-errCh:
-				err = errr
-			default:
+			if err == nil {
+				err = <-errCh
 			}
-
 			elapsed := time.Since(start)
 
 			if (err != nil) != tt.wantErr {


### PR DESCRIPTION
This pull request refactors the `Executor.Run` method and its usage to improve concurrency handling by switching from returning results and errors directly to using channels for asynchronous result and error communication. The changes ensure better handling of concurrent command execution and error propagation, both in the main application and in tests.

**Executor concurrency refactor:**

* Changed the `Executor.Run` method signature to take result and error channels, and to send results/errors through these channels instead of returning them directly. This allows for asynchronous command execution and better error handling. [[1]](diffhunk://#diff-1ed01448420533c2991ad1ccc3099a659b6bd15e161d9fdb1eb27eefc9770dcfL51-L59) [[2]](diffhunk://#diff-1ed01448420533c2991ad1ccc3099a659b6bd15e161d9fdb1eb27eefc9770dcfL81-R87) [[3]](diffhunk://#diff-1ed01448420533c2991ad1ccc3099a659b6bd15e161d9fdb1eb27eefc9770dcfL100-L102)

**Command execution and error handling updates:**

* Updated `cmd/root.go` to use the new channel-based interface for running commands, processing results and errors asynchronously, and handling early termination on error. [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL56-R64) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR77-R89)

**Testing adjustments:**

* Refactored `executor_test.go` to accommodate the new channel-based interface, collecting results and handling errors via channels in tests.