### PR TITLE
feat: support retry ( `--max-retries-per-command` )

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ hello
 $ concrun --fail-fast -c "make test" -c "make lint" -c "make build"
 ```
 
+### Retry on failure
+
+```console
+$ concrun --max-retries-per-command 3 -c "flaky-test.sh" -c "another-test.sh"
+```
+
 ### Complex command combinations
 
 ```console
@@ -37,6 +43,42 @@ $ concrun \
   -c "npm run test:unit" \
   -c "npm run test:integration"
 # Runs Docker build and tests concurrently
+```
+
+## Options
+
+### `--max-retries-per-command`
+
+Specifies the maximum number of times to automatically retry each command if it fails. The default is 0 (no retries).
+
+- Commands will be executed repeatedly until they succeed (exit code 0) or until the specified number of retries is reached
+- All retry attempts are logged
+
+```console
+$ concrun --max-retries-per-command 3 -c "npm test" -c "npm run lint"
+```
+
+### `--fail-fast`
+
+Cancels other running commands if any command fails. The default is false (all commands run to completion).
+
+- The determination is made **after all retries for each command are completed**
+- This means that for each command type, failure is determined only after all of its retries have been exhausted
+
+```console
+$ concrun --fail-fast -c "make test" -c "make lint"
+```
+
+### Option Interactions
+
+When both options are used together:
+
+1. When a command fails, it first retries up to the specified number of times
+2. After all retries are complete, the final exit code is checked
+3. If the exit code is non-zero, other commands are cancelled
+
+```console
+$ concrun --fail-fast --max-retries-per-command 2 -c "npm test" -c "npm run build"
 ```
 
 ## Install

--- a/exector/exector.go
+++ b/exector/exector.go
@@ -16,14 +16,16 @@ import (
 const DefaultShell = "bash"
 
 type Executor struct {
-	commands []string
-	stdout   io.Writer
-	stderr   io.Writer
-	shell    string
-	failFast bool
+	commands             []string
+	stdout               io.Writer
+	stderr               io.Writer
+	shell                string
+	failFast             bool
+	maxRetriesPerCommand int
 }
 
 type Result struct {
+	Index     int
 	Command   string
 	Stdout    []byte
 	Stderr    []byte
@@ -31,6 +33,7 @@ type Result struct {
 	ExitCode  int
 	StartTime time.Time
 	EndTime   time.Time
+	Retries   int
 }
 
 func New(commands []string, opts ...Option) (*Executor, error) {
@@ -61,44 +64,75 @@ func (e *Executor) Run(ctx context.Context, ch chan<- *Result, errCh chan<- erro
 		return
 	}
 	var eg errgroup.Group
-	eg.SetLimit(runtime.GOMAXPROCS(0) - 1)
-	for _, c := range e.commands {
+	eg.SetLimit(runtime.NumCPU())
+	for i, c := range e.commands {
 		eg.Go(func() error {
-			cmd := exec.CommandContext(ctx, sh, "-c", c)
-			stdout := &bytes.Buffer{}
-			stderr := &bytes.Buffer{}
-			combined := &bytes.Buffer{}
-			cmd.Stdout = io.MultiWriter(stdout, combined)
-			cmd.Stderr = io.MultiWriter(stderr, combined)
-			exitCode := -1
-			var start time.Time
-			defer func() {
-				result := &Result{
-					Command:   c,
-					Stdout:    stdout.Bytes(),
-					Stderr:    stderr.Bytes(),
-					Combined:  combined.Bytes(),
-					ExitCode:  exitCode,
-					StartTime: start,
-					EndTime:   time.Now(),
-				}
-				if ch != nil {
-					ch <- result
-				}
-			}()
-			start = time.Now()
-			if err := cmd.Run(); err != nil {
-				var exitErr *exec.ExitError
-				if errors.As(err, &exitErr) {
-					if e.failFast {
-						cancel()
+			retries := 0
+			finished := false
+			lastExitCode := -1
+			for {
+				err := func() error {
+					cmd := exec.CommandContext(ctx, sh, "-c", c)
+					stdout := &bytes.Buffer{}
+					stderr := &bytes.Buffer{}
+					combined := &bytes.Buffer{}
+					cmd.Stdout = io.MultiWriter(stdout, combined)
+					cmd.Stderr = io.MultiWriter(stderr, combined)
+					exitCode := -1
+					start := time.Now()
+					defer func() {
+						result := &Result{
+							Index:     i,
+							Command:   c,
+							Stdout:    stdout.Bytes(),
+							Stderr:    stderr.Bytes(),
+							Combined:  combined.Bytes(),
+							ExitCode:  exitCode,
+							StartTime: start,
+							EndTime:   time.Now(),
+							Retries:   retries,
+						}
+						if ch != nil {
+							ch <- result
+						}
+						lastExitCode = exitCode
+						retries++
+					}()
+					if err := cmd.Run(); err != nil {
+						var exitErr *exec.ExitError
+						if !errors.As(err, &exitErr) {
+							return err
+						}
+						select {
+						case <-ctx.Done():
+							finished = true
+							return nil
+						default:
+						}
 					}
 					exitCode = cmd.ProcessState.ExitCode()
+					if exitCode == 0 {
+						finished = true
+						return nil
+					}
+					if retries >= e.maxRetriesPerCommand {
+						finished = true
+						return nil
+					}
 					return nil
+				}()
+				if err != nil {
+					return err
 				}
-				return err
+				if finished {
+					break
+				}
 			}
-			exitCode = cmd.ProcessState.ExitCode()
+			if e.failFast {
+				if lastExitCode != 0 {
+					cancel()
+				}
+			}
 			return nil
 		})
 	}

--- a/exector/option.go
+++ b/exector/option.go
@@ -1,5 +1,7 @@
 package exector
 
+import "github.com/k1LoW/errors"
+
 type Option func(*Executor) error
 
 func FailFast(failFast bool) Option {
@@ -12,6 +14,16 @@ func FailFast(failFast bool) Option {
 func Shell(shell string) Option {
 	return func(e *Executor) error {
 		e.shell = shell
+		return nil
+	}
+}
+
+func MaxRetriesPerCommand(n int) Option {
+	return func(e *Executor) error {
+		if n < 0 {
+			return errors.New("max retries per command must be 0 or greater")
+		}
+		e.maxRetriesPerCommand = n
 		return nil
 	}
 }


### PR DESCRIPTION
This pull request adds support for automatically retrying commands on failure in the `concrun` CLI tool, along with improved documentation and tests. The main feature is the new `--max-retries-per-command` option, which allows users to specify how many times each command should be retried if it fails. The codebase and tests have been updated to support and validate this behavior.

**New Feature: Retry on Failure**

* Added a `--max-retries-per-command` option to `concrun`, allowing users to specify the maximum number of retries for each command; commands are retried until they succeed or the retry limit is reached, and this is reflected in both the CLI and the executor logic (`cmd/root.go`, `exector/exector.go`, `exector/option.go`, `README.md`). [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR37) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR52) [[3]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR117) [[4]](diffhunk://#diff-1ed01448420533c2991ad1ccc3099a659b6bd15e161d9fdb1eb27eefc9770dcfR24-R36) [[5]](diffhunk://#diff-8feb15e76d687351e6ada6cd95bb6361eff9af1603250e14a99b61ed0860ca89R20-R29) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R32-R37) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R48-R83)

* Updated the documentation in `README.md` to explain the new `--max-retries-per-command` option, its interaction with `--fail-fast`, and provided usage examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R32-R37) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R48-R83)

**Executor and Command Handling Improvements**

* Modified the executor to track retries, command indices, and exit codes for each command, ensuring correct behavior when combining retries and fail-fast logic (`exector/exector.go`, `cmd/root.go`). [[1]](diffhunk://#diff-1ed01448420533c2991ad1ccc3099a659b6bd15e161d9fdb1eb27eefc9770dcfR24-R36) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL61-R63) [[3]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL72-R74) [[4]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR91-R96)

* Added input validation for the retry option to prevent negative values (`exector/option.go`).

**Internal Refactoring**

* Improved the way exit codes are collected and reported for multiple commands, especially when retries are involved (`cmd/root.go`). [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL61-R63) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL72-R74) [[3]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR91-R96)

* Added tracking of command index and retry count in the executor's `Result` structure to facilitate accurate reporting and testing (`exector/exector.go`).

These changes together make `concrun` more robust for running flaky or unreliable commands, with clear user feedback and improved test coverage.